### PR TITLE
Utilise pipy pour la lib exactonline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ python-dateutil==2.7.3
 python-editor==1.0.3
 six==1.11.0
 SQLAlchemy==1.2.12
-
--e git+https://github.com/gvisniuc/exactonline.git@0527ff2f814aa93af8a21a504990ad1e13a058e8#egg=exactonline
+exactonline==0.3.4


### PR DESCRIPTION
On attendais que https://github.com/ossobv/exactonline/pull/23 soit fusionné pour pouvoir utiliser la version de pipy pour exactonline